### PR TITLE
Update package validation baseline to 0.1.0-preview.1.1.1

### DIFF
--- a/src/Pure.RelationalSchema.Self.Storage.Introjection/Pure.RelationalSchema.Self.Storage.Introjection.csproj
+++ b/src/Pure.RelationalSchema.Self.Storage.Introjection/Pure.RelationalSchema.Self.Storage.Introjection.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsAotCompatible>false</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.1.1.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.1.1.1</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema.Self.Storage.Introjection</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.1.0-preview.1.1.0` to `0.1.0-preview.1.1.1` following the successful publish.